### PR TITLE
Update upload-pages-artifact Action to v4.0.0

### DIFF
--- a/github-pages/upload-pages-artifact/action.yml
+++ b/github-pages/upload-pages-artifact/action.yml
@@ -15,6 +15,6 @@ runs:
   steps:
     - name: Upload Pages Artifact
       id: upload_pages_artifact
-      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
       with:
         path: ${{ inputs.path }}


### PR DESCRIPTION
This version pins its underlying action by SHA